### PR TITLE
Add option to pass puppeteer config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ pandoc tests/sample.md -o sample.pdf --filter pandoc-mermaid
 The mermaid binary must be in your `$PATH` or can be set with the
 `MERMAID_BIN` environment variable.
 
+By setting the environment variable `PUPPETEER_CFG`, you can pass a custom
+configuration file to `mermaid` (`-p` option).
+
 ## But there is ...
 
 There are a few other filters trying to convert mermaid code blocks however

--- a/pandoc_mermaid_filter.py
+++ b/pandoc_mermaid_filter.py
@@ -7,8 +7,9 @@ import subprocess
 from pandocfilters import toJSONFilter, Para, Image
 from pandocfilters import get_filename4code, get_caption, get_extension
 
+# Environment variables with fallback values
 MERMAID_BIN = os.environ.get('MERMAID_BIN', 'mermaid')
-
+PUPPETEER_CFG = os.environ.get('PUPPETEER_CFG', None)
 
 def mermaid(key, value, format_, _):
     if key == 'CodeBlock':
@@ -28,7 +29,13 @@ def mermaid(key, value, format_, _):
                 with open(src, "wb") as f:
                     f.write(txt)
 
-                subprocess.check_call([MERMAID_BIN, "-i", src, "-o", dest])
+                # Default command to execute
+                cmd = [MERMAID_BIN, "-i", src, "-o", dest]
+
+                if PUPPETEER_CFG is not None:
+                    cmd.extend(["-p", PUPPETEER_CFG])
+
+                subprocess.check_call(cmd)
                 sys.stderr.write('Created image ' + dest + '\n')
 
             return Para([Image([ident, [], keyvals], caption, [dest, typef])])


### PR DESCRIPTION
A puppeteer config file can be passed to `mermaid` by setting the
environment variable `PUPPETEER_CFG`.

Closes: #2