### PR TITLE
Added stdout and stderr to check_call

### DIFF
--- a/pandoc_mermaid_filter.py
+++ b/pandoc_mermaid_filter.py
@@ -8,7 +8,7 @@ from pandocfilters import toJSONFilter, Para, Image
 from pandocfilters import get_filename4code, get_caption, get_extension
 
 # Environment variables with fallback values
-MERMAID_BIN = os.path.expanduser(os.environ.get('MERMAID_BIN', 'mermaid'))
+MERMAID_BIN = os.path.expanduser(os.environ.get('MERMAID_BIN', 'mmdc'))
 PUPPETEER_CFG = os.environ.get('PUPPETEER_CFG', None)
 
 

--- a/pandoc_mermaid_filter.py
+++ b/pandoc_mermaid_filter.py
@@ -39,7 +39,7 @@ def mermaid(key, value, format_, _):
                 if os.path.isfile('.puppeteer.json'):
                     cmd.extend(["-p", ".puppeteer.json"])
 
-                subprocess.check_call(cmd)
+                subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 sys.stderr.write('Created image ' + dest + '\n')
 
             return Para([Image([ident, [], keyvals], caption, [dest, typef])])


### PR DESCRIPTION
It seems, that with long pandoc-files, something happens with stdout and we get the error `BlockingIOError: [Errno 11] write could not complete without blocking`. To avoid this, we can just ignore stderr and stdout from the mermaid call, as they are not used in any case. After adding this parameters, the error vanishes.