### PR TITLE
Update default MERMAID_BIN to mmdc

### DIFF
--- a/pandoc_mermaid_filter.py
+++ b/pandoc_mermaid_filter.py
@@ -8,7 +8,7 @@ from pandocfilters import toJSONFilter, Para, Image
 from pandocfilters import get_filename4code, get_caption, get_extension
 
 # Environment variables with fallback values
-MERMAID_BIN = os.path.expanduser(os.environ.get('MERMAID_BIN', 'mermaid'))
+MERMAID_BIN = os.path.expanduser(os.environ.get('MERMAID_BIN', 'mmdc'))
 PUPPETEER_CFG = os.environ.get('PUPPETEER_CFG', None)
 
 


### PR DESCRIPTION
@timofurrer As per the latest release of `mermaid-cli`, the standard name for the Mermaid compiler is `mmdc`.

See: https://github.com/mermaid-js/mermaid-cli